### PR TITLE
fixed velocity, command line arguments, floats with commata

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,14 @@ Steps for Mac/OSX (will be similar for other platforms):
 ## Usage
 * Create a spectral analysis using SPEAR. Use a relatively high 'Minimum amplitude threshold' value (e.g. -20dB) for best results.
 * In SPEAR, under 'File' -> 'Export Format' select 'Text - Partials', then 'File' -> 'Export As...'
-* Save the file inside the SPEAR_to_MIDI folder with the exact filename `SPEAR.txt`
+* Save the file inside the SPEAR_to_MIDI folder.
 * Open Terminal and navigate to the SPEAR_to_MIDI folder.
-* Type the command `python3 SPEAR_to_MIDI.py` to run the program.
-* A MIDI file called `output.mid` will have been created inside the SPEAR_to_MIDI folder. This can be opened and edited in a score editing program like Sibelius or MuseScore.
+* Type the command `python3 SPEAR_to_MIDI.py input_file output_file bpm` to run the program. Replace input_file, output_file and bpm with your files and choice for bpm. You do not have to specify them, the default to: input_file = "SPEAR.txt", output_file = "output.mid" and bpm = 60.
+* A MIDI file with the specified name will then be created. This can be opened and edited in a score editing program like Sibelius or MuseScore.
 
 ## Limitations
 
 * The program works best for relatively simple spectral analyses that don't have large numbers of simultaneous partials. If the program fails, try setting a higher value for 'Minimum amplitude threshold' when analysing the audio in SPEAR.
-* `output.mid` is overwritten every time the program is run. To avoid accidentally losing data, save the file elsewhere on your computer after running the program.
 
 ## Data interpretation details
 

--- a/SPEAR_to_MIDI.py
+++ b/SPEAR_to_MIDI.py
@@ -1,18 +1,34 @@
 import functions
 from mido import MidiTrack, MetaMessage, Message, MidiFile, bpm2tempo
 from time import perf_counter
+import sys
+
+# Access command-line arguments
+arguments = sys.argv
+if len(arguments) > 1:
+    input_file = str(arguments[1])
+else:
+    input_file = 'SPEAR.txt'
+if len(arguments) > 2:
+    output_file = str(arguments[2])
+else:
+    output_file = 'output.mid'
+if len(arguments) > 3:
+    bpm = int(arguments[3])
+else:
+    bpm = 60
 
 # Set beat resolution: Pulses (ticks) per quarter note. Normally 480.
 PPQN = 480
 # Set tempo. Converts bpm to MIDI tempo value (microseconds per quarter note).
-tempo = bpm2tempo(60)
+tempo = bpm2tempo(bpm)
 
 
 # Read input file
 print('--- SPEAR to MIDI ---')
 print('Reading file...')
 t1 = perf_counter()
-with open('SPEAR.txt', 'r') as f:
+with open(input_file, 'r') as f:
     lines = f.readlines()
 t2 = perf_counter()
 print('Complete ({:.2f}ms)'.format((t2 - t1) * 1000))
@@ -86,6 +102,6 @@ for event in midi_events:
 # Create a MidiFile object, append our track, save the file
 midifile = MidiFile()
 midifile.tracks.append(track0)
-midifile.save('output.mid')
+midifile.save(output_file)
 
 print('COMPLETE')

--- a/functions.py
+++ b/functions.py
@@ -78,7 +78,7 @@ def process_line(line):
     while len(split_line) > 0:
         timepoint = []
         for i in range(3):
-            item = float(split_line.pop(0))
+            item = float(split_line.pop(0).replace(',', '.'))
             timepoint.append(item)
         partial.append(timepoint)
 


### PR DESCRIPTION
As the title suggests, I fixed the velocity output to the midi file and made it scale automatically. Also the input and output file are not hardcoded anymore and accessable via command line arguments. I'm on Windows and my version of Spear did output the files with floats of style 0,1234 - they can now also be parsed. 

Cheers!